### PR TITLE
Support flask 3.0

### DIFF
--- a/lmfdb/cluster_pictures/cluster_picture.py
+++ b/lmfdb/cluster_pictures/cluster_picture.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask import Markup
+from markupsafe import Markup
 
 from lmfdb.app import app
 from lmfdb.cluster_pictures.web_cluster_picture import (

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -5,7 +5,6 @@ import re
 import time
 from collections import defaultdict, Counter
 from flask import (
-    Markup,
     make_response,
     redirect,
     render_template,
@@ -14,6 +13,7 @@ from flask import (
     url_for,
     abort,
 )
+from markupsafe import Markup
 #from six import BytesIO
 from string import ascii_lowercase
 from io import BytesIO

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -3,7 +3,8 @@
 import os
 import re
 
-from flask import abort, render_template, request, url_for, redirect, send_file, make_response, Markup
+from flask import abort, render_template, request, url_for, redirect, send_file, make_response
+from markupsafe import Markup
 from sage.all import ZZ, QQ, PolynomialRing, NumberField, latex, prime_range, RealField, log
 from lmfdb import db
 from lmfdb.app import app


### PR DESCRIPTION
Using `from flask import Markup` was deprecated and removed in flask 3.

Replace it with `from markupsafe import Markup`.